### PR TITLE
createStore Feature 

### DIFF
--- a/DOCUMENTATION.md
+++ b/DOCUMENTATION.md
@@ -1,3 +1,34 @@
+## createStore Usage
+
+To create the store, use the `createStore()` function. For example, to create a store and add all the variables which you want to access anywhere from the application, you would use the following code:
+
+```javascript
+
+const storeObject = {
+    name: "John Doe",
+    age: 35,
+    univerity: "Stanford",
+    isGraduated: false
+}
+
+// stores the object in "store"
+const store = createStore(storeObject);
+
+// returns {the object, getState function, updateState function}
+
+// prints "John Doe"
+console.log(store.name)
+
+// updateState changes the state and returns "updated store"
+store = store.updateState("name","John Smith");
+
+const age = store.getState("age");
+
+console.log(age); // prints 35
+```
+
+Note: createStore() cannot be invoked or called more than once
+
 ## updateState Usage
 
 To update the state of the store, use the `updateState()` function. For example, to update the title property of the store to 'My New Title', you would use the following code:

--- a/DOCUMENTATION.md
+++ b/DOCUMENTATION.md
@@ -11,23 +11,26 @@ const storeObject = {
     isGraduated: false
 }
 
-// stores the object in "store"
-const store = createStore(storeObject);
+// creates a "store" and stores the object
+createStore(storeObject);
 
-// returns {the object, getState function, updateState function}
-
-// prints "John Doe"
-console.log(store.name)
-
-// updateState changes the state and returns "updated store"
-store = store.updateState("name","John Smith");
-
-const age = store.getState("age");
-
-console.log(age); // prints 35
+// to retrieve the "store object" use getStore()
 ```
 
-Note: createStore() cannot be invoked or called more than once
+Note: `createStore()` cannot be invoked or called more than once even in different script files of the same application.
+
+## getState Usage
+
+To get the state of the store, use the `getState()` function. For example, to get the state of the `key`, you would use the following code:
+
+```javascript
+const value = store.getState(key);
+
+// prints value of the key
+console.log(value);
+```
+
+Note: the function throws an error if the value doesn't exist.
 
 ## updateState Usage
 
@@ -76,8 +79,8 @@ import { readContent } from "./index.js";
 
 const domManager = readContent();
 
-// single element property value (innerHTML) returned 
-const data = domManager.read(".para","innerHTML");
+// single element property value (innerHTML) returned
+const data = domManager.read(".para", "innerHTML");
 
 console.log(data);
 ```
@@ -90,7 +93,7 @@ import { readContent } from "./index.js";
 const domManager = readContent();
 
 // multiple elements property values (innerHTML) returned in an array
-const data = domManager.read(".para","innerHTML",true);
+const data = domManager.read(".para", "innerHTML", true);
 
 console.log(data);
 ```
@@ -103,7 +106,7 @@ import { readContent } from "./index.js";
 const domManager = readContent();
 
 // the html DOM element itself is returned
-const data = domManager.read(".para",false);
+const data = domManager.read(".para", false);
 
 console.log(data);
 ```
@@ -114,7 +117,7 @@ import { readContent } from "./index.js";
 const domManager = readContent();
 
 // the html DOM elements itself is returned in an array
-const data = domManager.read(".para",true);
+const data = domManager.read(".para", true);
 
 console.log(data);
 ```

--- a/template/src/store/createStore.js
+++ b/template/src/store/createStore.js
@@ -1,27 +1,38 @@
-import getState from "./getState.js";
-import updateState from "./updateState.js";
+const create = () => {
 
-const createStore = ( storeObject ) => {
-
-    /* Global store creation for entire access */
-    const _store = storeObject;
-
-    /* handling refresh */
-    window.onbeforeunload = () => {
-        localStorage.removeItem("store");
-    }
-
-    /* handling function invoking more than once */
-    if (localStorage.getItem("store")) {
+    const _error = () => {
         console.error("Store already exists.")
         throw new Error("Cannot invoke createStore more than once.");
     }
+   
+    const createStore = (storeObject ) => {
+    
+        /* Global store creation for entire access */
+        const _store = storeObject;
 
-    /* Creation of store */
-    localStorage.setItem("store", JSON.stringify(storeObject));
+        /* handling refresh */
+        window.onbeforeunload = () => {
+            localStorage.setItem("isLoading","true");
+        }
+        
+        /* in case of store does not exist */
+        if (!localStorage.getItem("store")) {
+            localStorage.setItem("store", JSON.stringify(_store));
+        }
+        
+        /* if store exists and it is not reloading */
+        if (localStorage.getItem("store") &&
+            !JSON.parse(localStorage.getItem("isLoading"))) {
+            _error();
+        }
 
-    return {..._store, getState, updateState};
+        /* indicates reloading is complete */
+        localStorage.setItem("isLoading","false");
+    }
+
+    return { createStore };
+
 }
 
-export default createStore;
+export default create().createStore;
 

--- a/template/src/store/createStore.js
+++ b/template/src/store/createStore.js
@@ -1,0 +1,27 @@
+import getState from "./getState.js";
+import updateState from "./updateState.js";
+
+const createStore = ( storeObject ) => {
+
+    /* Global store creation for entire access */
+    const _store = storeObject;
+
+    /* handling refresh */
+    window.onbeforeunload = () => {
+        localStorage.removeItem("store");
+    }
+
+    /* handling function invoking more than once */
+    if (localStorage.getItem("store")) {
+        console.error("Store already exists.")
+        throw new Error("Cannot invoke createStore more than once.");
+    }
+
+    /* Creation of store */
+    localStorage.setItem("store", JSON.stringify(storeObject));
+
+    return {..._store, getState, updateState};
+}
+
+export default createStore;
+

--- a/template/src/store/getState.js
+++ b/template/src/store/getState.js
@@ -1,0 +1,18 @@
+function getState(key) {
+
+    if (key === "" || typeof(key) !== "string" ) {
+        console.error("Invalid key");
+        throw new Error("Invalid key");
+    }
+
+    // if the value of the key is undefined , gives an error and returns undefined
+    if (this[key] === undefined) {
+        console.error("The value of the key is undefined ");
+        throw new Error("Value is undefined");
+    }
+    
+    return this[key];
+
+}
+
+export default getState;

--- a/template/src/store/updateState.js
+++ b/template/src/store/updateState.js
@@ -23,7 +23,17 @@ function updateState(key, newValue) {
       throw new Error('New value must be defined.');
     }
   
+    /* Update Local Storage */
+    
+    const data = JSON.parse(localStorage.getItem("store"));
+    
+    data[key] = newValue;
+    
+    localStorage.setItem("store", JSON.stringify(data));
+
     this[key] = newValue;
-  
+
     return this;
   }
+
+export default updateState;

--- a/template/src/store/updateState.js
+++ b/template/src/store/updateState.js
@@ -22,17 +22,16 @@ function updateState(key, newValue) {
     if (newValue === undefined || newValue === null) {
       throw new Error('New value must be defined.');
     }
-  
-    /* Update Local Storage */
-    
-    const data = JSON.parse(localStorage.getItem("store"));
-    
-    data[key] = newValue;
-    
-    localStorage.setItem("store", JSON.stringify(data));
 
     this[key] = newValue;
 
+    /* Update the state of localStorage */
+    const data = JSON.parse(localStorage.getItem("store"));
+
+    data[key] = newValue;
+
+    localStorage.setItem("store",JSON.stringify(data));
+  
     return this;
   }
 


### PR DESCRIPTION
Hi @lindelwa122 , so I have worked on this issue, the approach goes as follows:

- To make the store global and access it from anywhere in the app I have used `localStorage` to store the object passed by the user
- Then I have given functionality where the user cannot call the function twice if he does it throws an error
- I have also worked on an exception where when the page is refreshed, it doesn't throw an error
- I have returned the store in createStore alongwith `updateState` `getState` so that the store can use it.
-  if updateState has to be called i can simply return it with store by importing it but the point is I had to make a few changes in updateState to change the state of the store in the localStorage.
- To retrieve store from localStorage, a new `getStore` function has to be created so that  user can retrieve it from anywhere that object returned will contains `variables`,`getState`,`updateState` I will take up this issue after createStore

Go through the documentation once 